### PR TITLE
optimized DelWildCard function without loop

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,8 +16,8 @@ type RedisCache interface {
 	Set(ctx context.Context, key string, value string, expiration int) error
 	// Get retrieves a key from the cache.
 	Get(ctx context.Context, key string) (string, error)
-	// Del deletes a key from the cache.
-	Del(ctx context.Context, key string) error
+	// Del deletes keys from the cache.
+	Del(ctx context.Context, keys ...string) error
 	/*
 		DelWildCard deletes all keys that match the wildcard pattern.
 		Patterns examples:
@@ -74,9 +74,9 @@ func (c *cache) Get(ctx context.Context, key string) (string, error) {
 	return c.client.Get(ctx, key).Result()
 }
 
-// Del deletes a key from the cache.
-func (c *cache) Del(ctx context.Context, key string) error {
-	return c.client.Del(ctx, key).Err()
+// Del deletes keys from the cache.
+func (c *cache) Del(ctx context.Context, keys ...string) error {
+	return c.client.Del(ctx, keys...).Err()
 }
 
 // Ping checks if the cache is available.
@@ -97,10 +97,8 @@ func (c *cache) DelWildCard(ctx context.Context, wildcard string) error {
 		return err
 	}
 
-	for _, key := range keys {
-		if err := c.Del(ctx, key); err != nil {
-			return err
-		}
+	if err := c.Del(ctx, keys...); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Now, DelWildCard() function uses loop, Del() function in redis.Client deletes items with keys (example: ...string).