### PR TITLE
redis del error when keys are empty

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,6 +76,10 @@ func (c *cache) Get(ctx context.Context, key string) (string, error) {
 
 // Del deletes keys from the cache.
 func (c *cache) Del(ctx context.Context, keys ...string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+
 	return c.client.Del(ctx, keys...).Err()
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -122,6 +122,21 @@ func (trc *TestRedisCache) TestWildCardDel(t *testing.T) {
 	assert.Error(t, err, "Value should have been deleted from cache")
 }
 
+func (trc *TestRedisCache) TestDeleteEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	// test Del method with empty slice
+	err := trc.Del(ctx, []string{}...)
+	assert.NoError(t, err, "error while deleting empty slice")
+
+	err = trc.Del(ctx)
+	assert.NoError(t, err, "error while deleting empty slice")
+
+	// test DelWildCard method with empty data in Redis storage
+	err = trc.DelWildCard(ctx, "*")
+	assert.NoError(t, err, "error while deleting empty wildcard")
+}
+
 func TestCache(m *testing.T) {
 	// Setup test configuration
 	cfg := &Config{
@@ -138,4 +153,5 @@ func TestCache(m *testing.T) {
 	trc.TestHash(m)
 	trc.TestHashObject(m)
 	trc.TestWildCardDel(m)
+	trc.TestDeleteEmpty(m)
 }


### PR DESCRIPTION
when we remove redis data with empty slice, error occurs below.

ERR wrong number of arguments for 'del' command